### PR TITLE
feat(k6) - add k6 benchmarks

### DIFF
--- a/gatling-benchmarks/src/main/java/RustSalvoSimulation.java
+++ b/gatling-benchmarks/src/main/java/RustSalvoSimulation.java
@@ -16,7 +16,7 @@ public class RustSalvoSimulation extends Simulation {
             .acceptEncodingHeader("gzip, deflate")
             .userAgentHeader("Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
 
-    ScenarioBuilder scn = scenario("RustXitcaSimulation")
+    ScenarioBuilder scn = scenario("RustSalvoSimulation")
             .exec(http("request")
                     .get("/"))
             .pause(5);

--- a/k6-benchmarks/README.md
+++ b/k6-benchmarks/README.md
@@ -1,0 +1,23 @@
+Instructions to install XK6 Dashboard (make sure you are inside the k6-benchmarks folder):
+# Build
+To build a k6 binary with this extension, first ensure you have the prerequisites:
+
+Go toolchain
+
+Git
+
+### Then:
+
+Download xk6:
+> $ go install go.k6.io/xk6/cmd/xk6@latest
+
+Build the binary:
+
+> xk6 build --with github.com/grafana/xk6-dashboard@latest
+
+Then run the script you want to execute, i.e 
+>./run-gleam-mist-simulation.sh
+
+While execution is running, the dashboard will be accessible on your browser for live metrics on the following URL: http://127.0.0.1:5665
+
+After execution ends, HTML file with the metrics will be exported to a {simulation-name}.html file inside the results folder.

--- a/k6-benchmarks/run-bun-elysia.sh
+++ b/k6-benchmarks/run-bun-elysia.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=bun-elysia -e URL='http://localhost:3000/' --out dashboard=report=results/bun-elisya-1k.html test.js 

--- a/k6-benchmarks/run-bun-hono.sh
+++ b/k6-benchmarks/run-bun-hono.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=bun-hono -e URL='http://127.0.0.1:3000/' --out dashboard=report=results/bun-hono-1k.html test.js 

--- a/k6-benchmarks/run-bun-http-server-worker.sh
+++ b/k6-benchmarks/run-bun-http-server-worker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=bun-http-server-worker -e URL='http://127.0.0.1:3000/' --out dashboard=report=results/bun-http-server-worker-1k.html test.js 

--- a/k6-benchmarks/run-bun-http-server.sh
+++ b/k6-benchmarks/run-bun-http-server.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=bun-http-server -e URL='http://127.0.0.1:3000/' --out dashboard=report=results/bun-http-server-1k.html test.js 

--- a/k6-benchmarks/run-c-scratch.sh
+++ b/k6-benchmarks/run-c-scratch.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+./k6 run -e TEST=c-scratch -e URL='http://localhost:8080/' --out dashboard=report=results/c-scratch-1k.html test.js 

--- a/k6-benchmarks/run-clojure-ring-jetty.sh
+++ b/k6-benchmarks/run-clojure-ring-jetty.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=clojure-ring-jetty -e URL='http://localhost:3000/' --out dashboard=report=results/clojure-ring-jetty-1k.html test.js 

--- a/k6-benchmarks/run-cpp-drogon.sh
+++ b/k6-benchmarks/run-cpp-drogon.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=cpp-drogon -e URL='http://localhost:5555/' --out dashboard=report=results/cpp-drogon-1k.html test.js 

--- a/k6-benchmarks/run-crystal-spider-gazelle.sh
+++ b/k6-benchmarks/run-crystal-spider-gazelle.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=crystal-spider-gazelle -e URL='http://localhost:3000/uuid' --out dashboard=report=results/crystal-spider-gazelle-1k.html test.js 

--- a/k6-benchmarks/run-dartshelf.sh
+++ b/k6-benchmarks/run-dartshelf.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=dart-shelf -e URL='http://localhost:8080/' --out dashboard=report=results/dart-shelf-1k.html test.js 

--- a/k6-benchmarks/run-deno-fresh.sh
+++ b/k6-benchmarks/run-deno-fresh.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=deno-fresh -e URL='http://127.0.0.1:8000/' --out dashboard=report=results/deno-fresh-1k.html test.js 

--- a/k6-benchmarks/run-elixir-phoenix-cowboy.sh
+++ b/k6-benchmarks/run-elixir-phoenix-cowboy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=elixir-phoenix -e URL='http://localhost:4000/' --out dashboard=report=results/elixir-phoenix-1k.html test.js 

--- a/k6-benchmarks/run-gleam-mist.sh
+++ b/k6-benchmarks/run-gleam-mist.sh
@@ -1,0 +1,1 @@
+./k6 run -e TEST=gleam-mist -e URL='http://127.0.0.1:3000/uuid' --out dashboard=report=results/gleam-mist-1k.html test.js 

--- a/k6-benchmarks/run-go.sh
+++ b/k6-benchmarks/run-go.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=go -e URL='http://localhost:8080/' --out dashboard=report=results/go-1k.html test.js 

--- a/k6-benchmarks/run-haskell-scotty.sh
+++ b/k6-benchmarks/run-haskell-scotty.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=haskell-scotty -e URL='http://localhost:3000/' --out dashboard=report=results/haskell-scotty-1k.html test.js 

--- a/k6-benchmarks/run-haskell-warp.sh
+++ b/k6-benchmarks/run-haskell-warp.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=haskell-warp -e URL='http://localhost:3000/' --out dashboard=report=results/haskell-warp-1k.html test.js 

--- a/k6-benchmarks/run-java-blade.sh
+++ b/k6-benchmarks/run-java-blade.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=java-blade -e URL='http://127.0.0.1:9000/uuid' --out dashboard=report=results/java-blade-1k.html test.js 

--- a/k6-benchmarks/run-java-httpserver-virtual-threads.sh
+++ b/k6-benchmarks/run-java-httpserver-virtual-threads.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+./k6 run -e TEST=java-http-server-virtual-threads -e URL='http://localhost:8080/' --out dashboard=report=results/java-http-server-virtual-threads-1k.html test.js 

--- a/k6-benchmarks/run-java-httpserver.sh
+++ b/k6-benchmarks/run-java-httpserver.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=java-http-server -e URL='http://localhost:8080/' --out dashboard=report=results/java-http-server-1k.html test.js 

--- a/k6-benchmarks/run-java-iouring.sh
+++ b/k6-benchmarks/run-java-iouring.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=java-iouring -e URL='http://localhost:8080/' --out dashboard=report=results/java-iouring-1k.html test.js 

--- a/k6-benchmarks/run-julia-genie.sh
+++ b/k6-benchmarks/run-julia-genie.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=julia-genie -e URL='http://127.0.0.1:8002/' --out dashboard=report=results/julia-genie-1k.html test.js 

--- a/k6-benchmarks/run-kotlin-http4k.sh
+++ b/k6-benchmarks/run-kotlin-http4k.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=ktor -e URL='http://localhost:8080/uuid' --out dashboard=report=results-kotlin-http4k-1k.html test.js 

--- a/k6-benchmarks/run-kotlin-ktor.sh
+++ b/k6-benchmarks/run-kotlin-ktor.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=ktor -e URL='http://localhost:8080/' --out dashboard=report=results-ktor-1k.html test.js 

--- a/k6-benchmarks/run-lua-pegasus.sh
+++ b/k6-benchmarks/run-lua-pegasus.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=lua-pegasus -e URL='http://localhost:8080/u' --out dashboard=report=results/lua-pegasus-1k.html test.js 

--- a/k6-benchmarks/run-may_minihttp.sh
+++ b/k6-benchmarks/run-may_minihttp.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-may-mini -e URL='http://localhost:8080/' --out dashboard=report=results/rust-may-mini-1k.html test.js 

--- a/k6-benchmarks/run-micronaut.sh
+++ b/k6-benchmarks/run-micronaut.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=micronaut -e URL='http://localhost:8080/uuid' --out dashboard=report=results/micronaut-1k.html test.js 

--- a/k6-benchmarks/run-netty-mono.sh
+++ b/k6-benchmarks/run-netty-mono.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=netty-mono -e URL='http://localhost:8080/r' --out dashboard=report=results/netty-mono-1k.html test.js 

--- a/k6-benchmarks/run-netty-mono2.sh
+++ b/k6-benchmarks/run-netty-mono2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=netty-mono-2 -e URL='http://localhost:8080/r2' --out dashboard=report=results/netty-mono-2-1k.html test.js 

--- a/k6-benchmarks/run-netty.sh
+++ b/k6-benchmarks/run-netty.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=netty -e URL='http://localhost:8080/' --out dashboard=report=results/netty-1k.html test.js 

--- a/k6-benchmarks/run-nim2-beast.sh
+++ b/k6-benchmarks/run-nim2-beast.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=nim2-beast -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/nim2-beast-1k.html test.js 

--- a/k6-benchmarks/run-nodejs-http-server-worker.sh
+++ b/k6-benchmarks/run-nodejs-http-server-worker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=nodejs-server-worker -e URL='http://localhost:3000/' --out dashboard=report=results/nodejs-server-worker-1k.html test.js 

--- a/k6-benchmarks/run-nodejs-http-server.sh
+++ b/k6-benchmarks/run-nodejs-http-server.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=nodejs-http-server -e URL='http://localhost:3000/' --out dashboard=report=results/nodejs-http-server-1k.html test.js 

--- a/k6-benchmarks/run-nodejsexpress.sh
+++ b/k6-benchmarks/run-nodejsexpress.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=nodejs-express -e URL='http://localhost:3000/' --out dashboard=report=results/nodejs-express-1k.html test.js 

--- a/k6-benchmarks/run-ocaml-http_async.sh
+++ b/k6-benchmarks/run-ocaml-http_async.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=ocaml-http-async -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/ocaml-http-async-1k.html test.js 

--- a/k6-benchmarks/run-php-embeded-server.sh
+++ b/k6-benchmarks/run-php-embeded-server.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=php-embedded-server -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/php-embedded-server-1k.html test.js 

--- a/k6-benchmarks/run-php-nginx.sh
+++ b/k6-benchmarks/run-php-nginx.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=php-nginx -e URL='http://127.0.0.1:80' --out dashboard=report=results/php-nginx-1k.html test.js 

--- a/k6-benchmarks/run-python-fast-api-hypercorn.sh
+++ b/k6-benchmarks/run-python-fast-api-hypercorn.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=python-fast-api-hypercorn -e URL='http://localhost:8000/' --out dashboard=report=results/python-fast-api-hypercorn-1k.html test.js 

--- a/k6-benchmarks/run-python-fast-api.sh
+++ b/k6-benchmarks/run-python-fast-api.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+./k6 run -e TEST=python-fast-api -e URL='http://localhost:8000/' --out dashboard=report=results/python-fast-api-1k.html test.js 

--- a/k6-benchmarks/run-python-flask.sh
+++ b/k6-benchmarks/run-python-flask.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=python-flask -e URL='http://localhost:5000/' --out dashboard=report=results/python-flask-1k.html test.js 

--- a/k6-benchmarks/run-python-tornado.sh
+++ b/k6-benchmarks/run-python-tornado.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=python-tornado -e URL='http://localhost:8888/' --out dashboard=report=results/python-tornado-1k.html test.js 

--- a/k6-benchmarks/run-python-twisted.sh
+++ b/k6-benchmarks/run-python-twisted.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=python-twisted -e URL='http://localhost:8080/' --out dashboard=report=results/python-twisted-1k.html test.js 

--- a/k6-benchmarks/run-quarkus-native.sh
+++ b/k6-benchmarks/run-quarkus-native.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=quarkus-native -e URL='http://localhost:8080/uuid' --out dashboard=report=results/quarkus-native-1k.html test.js 

--- a/k6-benchmarks/run-quarkus-react.sh
+++ b/k6-benchmarks/run-quarkus-react.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=quarkus-react -e URL='http://localhost:8080/uuid' --out dashboard=report=results/quarkus-react-1k.html test.js 

--- a/k6-benchmarks/run-quarkus.sh
+++ b/k6-benchmarks/run-quarkus.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=quarkus -e URL='http://localhost:8080/' --out dashboard=report=results/quarkus-1k.html test.js 

--- a/k6-benchmarks/run-racket-spin.sh
+++ b/k6-benchmarks/run-racket-spin.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=racket-spin -e URL='http://localhost:8080/' --out dashboard=report=results/racket-spin-1k.html test.js 

--- a/k6-benchmarks/run-ruby.sh
+++ b/k6-benchmarks/run-ruby.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=ruby -e URL='http://localhost:8080/' --out dashboard=report=results/ruby-1k.html test.js 

--- a/k6-benchmarks/run-rustactix.sh
+++ b/k6-benchmarks/run-rustactix.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-actix -e URL='http://127.0.0.1:8080' --out dashboard=report=results/rust-actix-1k.html test.js 

--- a/k6-benchmarks/run-rustaxum.sh
+++ b/k6-benchmarks/run-rustaxum.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-axum -e URL='http://127.0.0.1:3000/' --out dashboard=report=results/rust-axum-1k.html test.js 

--- a/k6-benchmarks/run-rustgotham.sh
+++ b/k6-benchmarks/run-rustgotham.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-gotham -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/rust-gotham-1k.html test.js 

--- a/k6-benchmarks/run-rusthyper.sh
+++ b/k6-benchmarks/run-rusthyper.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-hyper -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/rust-hyper-1k.html test.js 

--- a/k6-benchmarks/run-rustsalvo.sh
+++ b/k6-benchmarks/run-rustsalvo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-salvo -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/rust-salvo-1k.html test.js 

--- a/k6-benchmarks/run-rustxitca.sh
+++ b/k6-benchmarks/run-rustxitca.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=rust-xitca -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/rust-xitca-1k.html test.js 

--- a/k6-benchmarks/run-scala3-play2.sh
+++ b/k6-benchmarks/run-scala3-play2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=scala3-play2 -e URL='http://localhost:9000/u' --out dashboard=report=results/scala3-play2-1k.html test.js 

--- a/k6-benchmarks/run-scala3-zio-http.sh
+++ b/k6-benchmarks/run-scala3-zio-http.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=scala3-zio-http -e URL='http://127.0.0.1:8080/u' --out dashboard=report=results/scala3-zio-http-1k.html test.js 

--- a/k6-benchmarks/run-scala3x-akka-http.sh
+++ b/k6-benchmarks/run-scala3x-akka-http.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=scala3x-akka-http -e URL='http://127.0.0.1:8080/uuid' --out dashboard=report=results/scala3x-akka-http-1k.html test.js 

--- a/k6-benchmarks/run-tomcat.sh
+++ b/k6-benchmarks/run-tomcat.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=tomcat -e URL='http://localhost:8080/' --out dashboard=report=results/tomcat-1k.html test.js 

--- a/k6-benchmarks/run-undertow.sh
+++ b/k6-benchmarks/run-undertow.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=go -e URL='http://localhost:8080/' --out dashboard=report=results/go-1k.html test.js 

--- a/k6-benchmarks/run-v-picov.sh
+++ b/k6-benchmarks/run-v-picov.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=v-picov -e URL='http://localhost:8080/' --out dashboard=report=results/v-picov-1k.html test.js 

--- a/k6-benchmarks/run-zigzap.sh
+++ b/k6-benchmarks/run-zigzap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=zigzap -e URL='http://localhost:3000/u' --out dashboard=report=results/zigzap-1k.html test.js 

--- a/k6-benchmarks/runjava-smart-http.sh
+++ b/k6-benchmarks/runjava-smart-http.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+ulimit -n 65000
+sudo sysctl -w net.ipv4.ip_local_port_range="1025 65535"
+echo 300000 | sudo tee /proc/sys/fs/nr_open
+echo 300000 | sudo tee /proc/sys/fs/file-max
+
+./k6 run -e TEST=java-smart-http -e URL='http://127.0.0.1:8080/' --out dashboard=report=results/java-smart-http-1k.html test.js 

--- a/k6-benchmarks/test.js
+++ b/k6-benchmarks/test.js
@@ -1,0 +1,27 @@
+import http from 'k6/http';
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+
+      // How long the test lasts
+      duration: '1m',
+
+      // How many iterations per timeUnit
+      rate: 1000,
+
+      // Start `rate` iterations per second
+      timeUnit: '1s',
+
+      // Pre-allocate VUs
+      preAllocatedVUs: 20,
+    },
+  },
+};
+
+export default () => {
+  const url = __ENV.URL
+  const urlRes = http.get(url);
+};


### PR DESCRIPTION
###  Adding K6 Benchmarks to the project
Language         [JS] <BR/>
Server/Framework [k6] <BR/>
Extra Notes: 
Adding k6 benchmarks for the servers in the project. 

Added a baseline test which receives url and test name through parameters, which will run a 1K-per-1-minute simulation (just like the gatling simulation), expose live metrics through http://127.0.0.1:5665 and after export an HTML file on the results folder.

Added scripts for each of the existing gatling simulations.

<BR/>


## Instructions:

Instructions to install XK6 Dashboard (make sure you are inside the k6-benchmarks folder):
# Build
To build a k6 binary with this extension, first ensure you have the prerequisites:

Go toolchain

Git

### Then:

Download xk6:
> $ go install go.k6.io/xk6/cmd/xk6@latest

Build the binary:

> xk6 build --with github.com/grafana/xk6-dashboard@latest

Then run the script you want to execute, i.e 
>./run-gleam-mist-simulation.sh

While execution is running, the dashboard will be accessible on your browser for live metrics on the following URL: http://127.0.0.1:5665

After execution ends, HTML file with the metrics will be exported to a {simulation-name}.html file inside the results folder.

