### PR TITLE
Update Http4kSimulation.java

### DIFF
--- a/gatling-benchmarks/src/main/java/Http4kSimulation.java
+++ b/gatling-benchmarks/src/main/java/Http4kSimulation.java
@@ -24,7 +24,7 @@ public class Http4kSimulation extends Simulation {
     {
         setUp(scn.
                 injectOpen(
-                        constantUsersPerSec(1_000).during(10)
+                        constantUsersPerSec(1_000).during(60)
                 )
         ).protocols(httpProtocol);
     }


### PR DESCRIPTION
Fixing number of requests to 60

# Servers Benchmark Pull Request
### PR Requirements

Please make sure your server port matches the script port matches the simulation and make sure you run in the browser. I will run in a Ubuntu 22.02 so it need to work on Linux. 

Mark this boxes with X if you did it right, otherwise go fix your pr!

PR Checklist:
- [x] 0. Did you run on Linux? Did you run Gatling? 
- [x] 1. Create a Gatling simulation
- [x] 2. Create a Gatling script (chmod +x pls) add the tuning for linux os pls 
- [x] 3. Create a run.sh script - add the tuning for linux os pls (chmod +x pls)
- [ ] 4. Add a different script to install dependencies(install-deps.sh)
- [x] 5. Don't publish gatling results

I will re-run on my machine, you can run all in our machine in our fork to compare different results with different hardware.

### Explain the PR in a couple of words please

Language         [] <BR/>
Server/Framework [] <BR/>
Extra Notes: <BR/>

### Any interesting tuning you want to explain?

N/A